### PR TITLE
VIP-190: Personal Sign Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The VIP author is responsible for building consensus within the community and do
 
 | No  | Title                       | Owner   | Category    | Status |
 | --- | --------------------------- | ------- | ----------- | ------ |
-| 3   | Personal Sign Standard      | Totient Labs | Interface | Draft  |
 | 180 | Fungible Token Standard     | VeChain | Application | Final  |
 | 181 | Non-Fungible Token Standard | VeChain | Application | Final  |
+| 190 | Personal Sign Standard      | Totient Labs | Interface | Draft  |
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The VIP author is responsible for building consensus within the community and do
 
 | No  | Title                       | Owner   | Category    | Status |
 | --- | --------------------------- | ------- | ----------- | ------ |
+| 3   | Personal Sign Standard      | Totient Labs | Interface | Draft  |
 | 180 | Fungible Token Standard     | VeChain | Application | Final  |
 | 181 | Non-Fungible Token Standard | VeChain | Application | Final  |
 

--- a/VIP-190-EN.md
+++ b/VIP-190-EN.md
@@ -1,5 +1,5 @@
 ---
-VIP: 3
+VIP: 190
 Title: Personal Sign Standard
 Category: Interface
 Author: Kevin Britz <kevin@totientlabs.com>
@@ -9,7 +9,7 @@ CreatedAt: 2019-02-05
 
 # Overview
 
-The below VIP-3 standard outlines an interface for personal sign when using `web3` to sign messages for VeChainThor dApps. This standard is based on Ethereum's [eth_sign](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign) RPC call, and modified to fit Vechain's signature standards.
+The below VIP-190 standard outlines an interface for personal sign when using `web3` to sign messages for VeChainThor dApps. This standard is based on Ethereum's [eth_sign](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign) RPC call, and modified to fit Vechain's signature standards.
 
 # Motivation
 

--- a/VIP-3-EN.md
+++ b/VIP-3-EN.md
@@ -1,0 +1,34 @@
+---
+VIP: 3
+Title: Personal Sign Standard
+Category: Interface
+Author: Kevin Britz <kevin@totientlabs.com>
+Status: Draft
+CreatedAt: 2019-02-05
+---
+
+# Overview
+
+The below VIP-3 standard outlines an interface for personal sign when using `web3` to sign messages for VeChainThor dApps. This standard is based on Ethereum's [eth_sign](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign) RPC call, and modified to fit Vechain's signature standards.
+
+# Motivation
+
+This standard is already in use in the Ledger Hardware Wallet application and Comet's implementation of `web3` personal sign. Standardization will ensure that dApps may support multiple clients with a single signature implementation.
+
+# Specification
+
+A prefix is necessary to ensure that a malicious dApp cannot sign or recover arbitrary messages. 
+
+```
+prefix = "\x19VeChain Signed Message:\n" + len(message)
+```
+
+To obtain the final payload for signature, we append the message to the prefix and hash with `blake2b256`
+
+```
+signature = sign(blake2b256(prefix + message))
+```
+
+# Implementation
+
+- https://github.com/LedgerHQ/ledger-app-vet


### PR DESCRIPTION
This standard outlines an interface for personal sign when using `web3` to sign messages for VeChainThor dApps. This standard is based on Ethereum's [eth_sign](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign) RPC call, and modified to fit Vechain's signature standards.