### PR TITLE
VIP180 superset of ERC20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/vips/VIP-180.md
+++ b/vips/VIP-180.md
@@ -66,7 +66,7 @@ Return: the balance of owner
 
 ### transfer
 
-    function transfer(address _to, uint256 _value) public
+    function transfer(address _to, uint256 _value) public returns (bool)
 
 Transfer `_value` amount of tokens to address `_to `, and **MUST** emit the `Transfer` event. The function **MUST** throw if the transaction failed.
 
@@ -75,10 +75,11 @@ Params:
 + _to: the receiver address
 + _value: the amount of tokens
 
+Return: true
 
 ### transferFrom
 
-    function transferFrom(address _from, address _to, uint256 _value) public
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool)
 
 Transfers `_value` amount of tokens from address `_from` to address `_to`, and **MUST** emit the `Transfer` event. The function **MUST** throw if the transaction failed.
 
@@ -88,10 +89,12 @@ Params:
 + _to: the receiver address
 + _value: the amount of tokens
 
+Return: true
+
 
 ### approve
 
-    function approve(address _spender, uint256 _value) public
+    function approve(address _spender, uint256 _value) public returns (bool)
 
 Allows `_spender` to withdraw from your account multiple times, up to the `_value` amount, and **MUST** emit the `Approval` event. If this function is called again it overwrites the current allowance with `_value`.
 
@@ -99,6 +102,8 @@ Params:
 
 + _spender: the spender address
 + _value: the amount of tokens
+
+Return: true
 
 
 ### allowance


### PR DESCRIPTION
I am requesting this pull because you mention: “The VIP-180 Standard is a superset of the [ERC20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md)”. However, this is not fully true for the functions below:

- function transfer(address _to, uint256 _value) public
- function transferFrom(address _from, address _to, uint256 _value) public
- function approve(address _spender, uint256 _value)

These functions according to Etherium’s EIP-20 documentation (provided on the link above from you) are as follows:

- function transfer(address _to, uint256 _value) public returns (bool success)
- function transferFrom(address _from, address _to, uint256 _value) public returns (bool success)
- function approve(address _spender, uint256 _value) public returns (bool success)

To me VIP180 doesn’t look like a superset of EIP-20 if it doesn’t behave the same way EIP-20 does. It leads to discrepancies between chains. 