### PR TITLE
Add error information to improve user experience

### DIFF
--- a/vips/VIP-201.md
+++ b/vips/VIP-201.md
@@ -128,12 +128,12 @@ B) The *authorization endpoint* authenticates the caller, then inspects the cont
 
 C) Assuming the signature is granted, then the response will be sent to the sender endpoint with the gas payer address, payer signature. If the request is denied, the error response will be sent.
 
-**Response Params**
+**Success Response Params**
 | name | description |
 | --- | --- |
 | signature | String. 65 bytes of signature, in hex format (132 chars). Prefixed with '0x'. |
 
-**Response Example**
+**Success Response Example**
 ```bash
 HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
@@ -144,7 +144,27 @@ Pragma: no-cache
 }
 ```
 
-Responses with HTTP status code other than **200** is considered an error.
+Responses with HTTP status code other than **200** is considered an error.  
+To support the client in error handling the response can optionally be of `Content-Type: application/json` and contain an error message.
+
+**Error Response Params**
+| name | description |
+| --- | --- |
+| message | String. Optional message with detailed information about the failed signed request. Human readable. |
+| code | String. Optional identifier of an occured error. Machine readable. |
+
+
+**Error Response Example**
+```bash
+HTTP/1.1 403 Forbidden
+Content-Type: application/json;charset=UTF-8
+Cache-Control: no-store
+Pragma: no-cache
+{
+    "message": "The origin is not allowed.",
+    "code": "REJECTED_ORIGIN"
+}
+```
 
 D) The sender validates the transaction body and the gas payer signature, adds the sender signature, assembles a valid transaction, and transmits it to the VeChain blockchain.
 


### PR DESCRIPTION
- The current process of delegation is built for success only.
- Clients are unable to identify potential problems and support users or developers to solve them.
- Adding error information will help developers to identify errors better and allow users to learn why a delegation failed.
- Due the already widely used implementation it is suggested to add a JSON output as optional and indicate its output by returning content type `application/json`